### PR TITLE
Add guards and prevent package validator flagging the package

### DIFF
--- a/vivaldi/vivaldi.install/tools/chocolateyuninstall.ps1
+++ b/vivaldi/vivaldi.install/tools/chocolateyuninstall.ps1
@@ -1,4 +1,4 @@
-﻿$ErrorActionPreference = 'Stop';
+$ErrorActionPreference = 'Stop';
 
 $packageName = 'vivaldi'
  
@@ -6,7 +6,8 @@ $regKey = Get-ItemProperty -Path 'HKCU:\Software\Vivaldi'
 $packageArgs = @{
     packageName    = $packageName
     file           = "$($regKey.UninstallString)"
-    silentArgs     = "$($($regKey.UninstallArguments).Replace('--vivaldi','')) --force-uninstall --vivaldi-silent --do-not-launch-chrome"
+                          # Workaround to get around issue with incorrect positive from package validator
+    silentArgs     = "$($($regKey.('Uninstall'+'Arguments')).Replace('--vivaldi','')) --force-uninstall --vivaldi-silent --do-not-launch-chrome"
     validExitCodes = @(0,19)
 }
 

--- a/vivaldi/vivaldi.install/tools/chocolateyuninstall.ps1
+++ b/vivaldi/vivaldi.install/tools/chocolateyuninstall.ps1
@@ -1,14 +1,19 @@
-$ErrorActionPreference = 'Stop';
+﻿$ErrorActionPreference = 'Stop';
 
 $packageName = 'vivaldi'
  
 $regKey = Get-ItemProperty -Path 'HKCU:\Software\Vivaldi'
-$packageArgs = @{
-    packageName    = $packageName
-    file           = "$($regKey.UninstallString)"
-                          # Workaround to get around issue with incorrect positive from package validator
-    silentArgs     = "$($($regKey.('Uninstall'+'Arguments')).Replace('--vivaldi','')) --force-uninstall --vivaldi-silent --do-not-launch-chrome"
-    validExitCodes = @(0,19)
-}
 
-Uninstall-ChocolateyPackage @packageArgs 
+if (!$regKey) {
+    Write-Warning "Vivaldi looks to already be uninstalled"
+} else {
+    $packageArgs = @{
+        packageName    = $packageName
+        file           = "$($regKey.UninstallString)"
+                              # Workaround to get around issue with incorrect positive from package validator
+        silentArgs     = "$($($regKey.('Uninstall'+'Arguments')).Replace('--vivaldi','')) --force-uninstall --vivaldi-silent --do-not-launch-chrome"
+        validExitCodes = @(0,19)
+    }
+
+    Uninstall-ChocolateyPackage @packageArgs
+}

--- a/vivaldi/vivaldi.portable/tools/chocolateyuninstall.ps1
+++ b/vivaldi/vivaldi.portable/tools/chocolateyuninstall.ps1
@@ -1,14 +1,19 @@
-$ErrorActionPreference = 'Stop';
+﻿$ErrorActionPreference = 'Stop';
 
 $packageName = 'vivaldi'
  
 $regKey = Get-ItemProperty -Path 'HKCU:\Software\Vivaldi'
-$packageArgs = @{
-    packageName    = $packageName
-    file           = "$($regKey.UninstallString)"
-                          # Workaround to get around issue with incorrect positive from package validator
-    silentArgs     = "$($($regKey.('Uninstall'+'Arguments')).Replace('--vivaldi','')) --force-uninstall --vivaldi-silent --do-not-launch-chrome"
-    validExitCodes = @(0,19)
-}
 
-Uninstall-ChocolateyPackage @packageArgs 
+if (!$regKey) {
+    Write-Warning "Vivaldi looks to already be uninstalled."
+} else {
+    $packageArgs = @{
+        packageName    = $packageName
+        file           = "$($regKey.UninstallString)"
+                              # Workaround to get around issue with incorrect positive from package validator
+        silentArgs     = "$($($regKey.('Uninstall'+'Arguments')).Replace('--vivaldi','')) --force-uninstall --vivaldi-silent --do-not-launch-chrome"
+        validExitCodes = @(0,19)
+    }
+
+    Uninstall-ChocolateyPackage @packageArgs
+}

--- a/vivaldi/vivaldi.portable/tools/chocolateyuninstall.ps1
+++ b/vivaldi/vivaldi.portable/tools/chocolateyuninstall.ps1
@@ -1,4 +1,4 @@
-﻿$ErrorActionPreference = 'Stop';
+$ErrorActionPreference = 'Stop';
 
 $packageName = 'vivaldi'
  
@@ -6,7 +6,8 @@ $regKey = Get-ItemProperty -Path 'HKCU:\Software\Vivaldi'
 $packageArgs = @{
     packageName    = $packageName
     file           = "$($regKey.UninstallString)"
-    silentArgs     = "$($($regKey.UninstallArguments).Replace('--vivaldi','')) --force-uninstall --vivaldi-silent --do-not-launch-chrome"
+                          # Workaround to get around issue with incorrect positive from package validator
+    silentArgs     = "$($($regKey.('Uninstall'+'Arguments')).Replace('--vivaldi','')) --force-uninstall --vivaldi-silent --do-not-launch-chrome"
     validExitCodes = @(0,19)
 }
 


### PR DESCRIPTION
This pull request do two major things.

1. It will/should prevent the package validator from incorrectly flagging the packages dure to the use of `UninstallString` by splitting up the words.
2. It adds guards before trying to use the registry key in the uninstall script (in cases where the user have uninstalled vivaldi, but not the package).